### PR TITLE
feat: add docker_compose_lib_dir and docker_compose_bin_dir options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python: "2.7"
 
 sudo: required
 dist: trusty
+group: deprecated-2017Q2
 
 addons:
   apt:

--- a/README.md
+++ b/README.md
@@ -1,39 +1,43 @@
-docker-compose
-===============
+# docker-compose
 
 [![Build Status](https://travis-ci.org/suzuki-shunsuke/ansible-docker-compose.svg?branch=master)](https://travis-ci.org/suzuki-shunsuke/ansible-docker-compose)
 
-Install Docker Compose.
+ansible role to install Docker Compose.
 
 https://galaxy.ansible.com/suzuki-shunsuke/docker-compose/
 
-Requirements
-------------
+## Requirements
 
 * Docker Engine
 
-Role Variables
---------------
+## Role Variables
 
-* docker_compose_path: the path where docker-compose is installed. The default is /usr/local/bin
-* docker_compose_mode: the permission of the docker-compose. The default is 0755
-* docker_compose_version: docker-compose version. The default is `1.11.2`
+name | required | default | example | description
+--- | --- | --- | --- | ---
+docker_compose_bin_dir: no | /usr/local/bin | | the directory path where the binary of docker-compose is installed
+docker_compose_lib_dir: no | /usr/local/lib | | the directory path where the binary of docker-compose is installed
+docker_compose_mode | no | 0755 | | the permission of the binary of docker-compose
+docker_compose_version | yes | 1.14.0 | docker-compose version
 
-Dependencies
-------------
+```
+{docker_compose_lib_dir}/docker-compose-{docker_compose_version}  #  binary
+{docker_compose_bin_dir|/docker-compose  # symbolic link
+```
+
+## Dependencies
 
 Nothing.
 
-Example Playbook
-----------------
+## Example Playbook
 
 ```yaml
 - hosts: servers
   roles:
   - role: suzuki-shunsuke.docker-compose
+    docker_compose_version: 1.14.0
+    become: yes
 ```
 
-License
--------
+## License
 
-MIT
+[MIT](LICENSE)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 # defaults file for docker-compose
-docker_compose_path: /usr/local/bin
+docker_compose_bin_dir: /usr/local/bin
+docker_compose_lib_dir: /usr/local/lib
 docker_compose_mode: 0755
-docker_compose_version: 1.11.2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,37 @@
 ---
 # tasks file for docker-compose
-- name: Install docker-compose
-  get_url:
-    url: https://github.com/docker/compose/releases/download/{{docker_compose_version}}/docker-compose-{{ansible_system}}-{{ansible_architecture}}
-    dest: "{{'{}/docker-compose'.format(docker_compose_path)}}"
-    mode: "{{docker_compose_mode}}"
-  become: "{{docker_compose_nonroot}}"
+- name: check whether the binary has already installed
+  stat:
+    path: "{{docker_compose_lib_dir}}/docker-compose-{{docker_compose_version}}"
+  register: lib_stat
+- block:
+  - name: mkdir docker_compose_lib_dir
+    file:
+      state: directory
+      dest: "{{docker_compose_lib_dir}}"
+  - name: install docker-compose
+    get_url:
+      url: https://github.com/docker/compose/releases/download/{{docker_compose_version}}/docker-compose-{{ansible_system}}-{{ansible_architecture}}
+      dest: "{{docker_compose_lib_dir}}/docker-compose-{{docker_compose_version}}"
+      mode: "{{docker_compose_mode}}"
+  when: not lib_stat.stat.exists
+- name: mkdir docker_compose_bin_dir
+  file:
+    state: directory
+    dest: "{{docker_compose_bin_dir}}"
+- name: check whether the binary has already installed
+  stat:
+    path: "{{docker_compose_bin_dir}}/docker-compose"
+  register: st
+- debug:
+    var: st
+- name: remove symbolic link
+  file:
+    state: absent
+    path: "{{docker_compose_bin_dir}}/docker-compose"
+  when: st.stat.exists and (not st.stat.islnk or st.stat.lnk_source != "{}/docker-compose-{}".format(docker_compose_lib_dir, docker_compose_version))
+- name: create symbolic link
+  file:
+    state: link
+    src: "{{docker_compose_lib_dir}}/docker-compose-{{docker_compose_version}}"
+    dest: "{{docker_compose_bin_dir}}/docker-compose"

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -2,11 +2,22 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "bento/ubuntu-16.04"
-  config.vm.provider "virtualbox" do |vb|
-    vb.memory = "2048"
+  config.vm.define "ubuntu" do |app|
+    app.vm.box = "bento/ubuntu-16.04"
+    app.vm.provider "virtualbox" do |vb|
+      vb.memory = "1024"
+    end
+    app.vm.provision "ansible" do |ansible|
+      ansible.playbook = "./test.yml"
+    end
   end
-  config.vm.provision "ansible" do |ansible|
-    ansible.playbook = "./test.yml"
+  config.vm.define "centos" do |app|
+    app.vm.box = "bento/centos-7.3"
+    app.vm.provider "virtualbox" do |vb|
+      vb.memory = "1024"
+    end
+    app.vm.provision "ansible" do |ansible|
+      ansible.playbook = "./test.yml"
+    end
   end
 end

--- a/tests/roles.yml
+++ b/tests/roles.yml
@@ -1,1 +1,2 @@
-- src: suzuki-shunsuke.docker-ubuntu
+- suzuki-shunsuke.docker-ubuntu
+- suzuki-shunsuke.docker-ce-centos

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,10 +1,16 @@
 ---
-- hosts: default
+- hosts: all
   roles:
-  - suzuki-shunsuke.docker-ubuntu
-  - ansible-docker-compose
+  - role: suzuki-shunsuke.docker-ubuntu
+    when: ansible_os_family == 'Debian'
+  - role: suzuki-shunsuke.docker-ce-centos
+    when: ansible_os_family == 'RedHat'
+  - role: ansible-docker-compose
+    docker_compose_version: 1.13.0
+    docker_compose_lib_dir: "{{ansible_env.HOME}}/lib"
+    docker_compose_bin_dir: "{{ansible_env.HOME}}/bin"
   tasks:
-  - command: docker-compose --version
+  - command: "{{ansible_env.HOME}}/bin/docker-compose --version"
     register: result
     changed_when: false
   - debug:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,0 @@
----
-# vars file for docker-compose
-docker_compose_nonroot: "{{ (ansible_env.HOME == '/root') | ternary('no', 'yes') }}"


### PR DESCRIPTION
BREAKING CHANGE:

* remove docker_compose_path and docker_compose_nonroot
* if the remote user does not have the write permission of `docker_compose_bin_dir` and
`docker_compose_lib_dir`, the role level become option is required.